### PR TITLE
Fix incorrect import statements

### DIFF
--- a/backend/clients/RealTimeClient.py
+++ b/backend/clients/RealTimeClient.py
@@ -1,11 +1,11 @@
 import logging
 
 from diart import OnlineSpeakerDiarization
-from backend.config import DIARIZATION_PIPELINE_CONFIG
+from config import DIARIZATION_PIPELINE_CONFIG
 import asyncio
 import diart.operators as dops
 import rx.operators as ops
-from backend.utils import concat, jsonify_transcription, StreamingSocketAudioSource
+from utils import concat, jsonify_transcription, StreamingSocketAudioSource
 import traceback
 import threading
 from clients.Client import Client

--- a/backend/clients/SequentialClient.py
+++ b/backend/clients/SequentialClient.py
@@ -2,9 +2,9 @@ import logging
 import asyncio
 import threading
 from diart.utils import decode_audio
-from backend.utils import save_batch_to_wav
+from utils import save_batch_to_wav
 import numpy as np
-from backend.config import STEP, TEMP_FILE_PATH
+from config import STEP, TEMP_FILE_PATH
 from pyannote.audio import Pipeline
 from clients.Client import Client
 

--- a/backend/clients/utils.py
+++ b/backend/clients/utils.py
@@ -3,9 +3,9 @@ from clients.RealTimeClient import RealTimeClient
 from clients.SequentialClient import SequentialClient
 from enum import Enum
 
-from backend.transcription.whisper_transcriber import WhisperTranscriber
-from backend.utils import format_whisper_model_name
-from backend.config import WhisperModelSize, LANGUAGE_MAPPING
+from transcription.whisper_transcriber import WhisperTranscriber
+from utils import format_whisper_model_name
+from config import WhisperModelSize, LANGUAGE_MAPPING
 
 
 class TranscriptionMethod(Enum):

--- a/backend/server.py
+++ b/backend/server.py
@@ -2,7 +2,7 @@ from faster_whisper import WhisperModel
 from diart import OnlineSpeakerDiarization
 from aiohttp import web
 import socketio
-from backend.client_manager import ClientManager
+from client_manager import ClientManager
 import logging
 import threading
 import asyncio

--- a/backend/transcription/whisper_transcriber.py
+++ b/backend/transcription/whisper_transcriber.py
@@ -2,8 +2,8 @@ import os
 import sys
 from contextlib import contextmanager
 import logging
-from backend.config import NON_ENGLISH_SPECIFIC_MODELS, TRANSCRIPTION_DEVICE, COMPUTE_TYPE
-from backend.utils import format_transcription, extract_speaker_id
+from config import NON_ENGLISH_SPECIFIC_MODELS, TRANSCRIPTION_DEVICE, COMPUTE_TYPE
+from utils import format_transcription, extract_speaker_id
 from faster_whisper import WhisperModel
 import stable_whisper
 from transcription.pyannote_utils import assign_speakers


### PR DESCRIPTION
Incorrect import statements caused a `Module Not Found` error, this should correctly assume the server file is being run from within the backend directory.