### PR TITLE
Implemented error handling for silence suppression call

### DIFF
--- a/backend/transcription/whisper_transcriber.py
+++ b/backend/transcription/whisper_transcriber.py
@@ -71,8 +71,8 @@ class WhisperTranscriber:
             if aligned_transcription['text'] == "":
                 logging.info("Empty aligned transcription, defaulting to original")
                 return self.current_transcription
-        except ValueError:
-            logging.info("Transcription alignment failed, defaulting to original")
+        except Exception as e:
+            logging.info(f"Transcription alignment failed, defaulting to original. Error: {e}")
             return self.current_transcription
 
         return aligned_transcription

--- a/interface/src/TranscribeOutput.js
+++ b/interface/src/TranscribeOutput.js
@@ -23,7 +23,7 @@ const TranscribeOutput = ({ data, classes }) => {
       const text = item.text;
       let speakerName = "";
 
-      if (speaker === -1) {
+      if (speaker === "unknown") {
         speakerName = "Unknown Speaker";
       } else {
         speakerName = `Speaker ${speaker + 1}`;


### PR DESCRIPTION
When stable-ts fails to suppress the silence, the app will default to the originally generated transcription.
Fixed a small issue with the "Unknown Speaker" label incorrectly appearing in the client.